### PR TITLE
Use CFFI-1.0 methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 __pycache__
+cairocffi/_ffi*.py
 *.egg-info
 /dist
 /.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ python:
 install:
   - "pip install xcffib"
   - "pip install ."
-  - "python cairocffi/ffi_build.py"
+  - "python -c 'import cffi, sys; sys.exit(cffi.__version_info__[0])' || python cairocffi/ffi_build.py"
 script: "py.test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ python:
 install:
   - "pip install xcffib"
   - "pip install ."
+  - "python cairocffi/ffi_build.py"
 script: "py.test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ install:
   - "pip install ."
   - "python -c 'import cffi, sys; sys.exit(cffi.__version_info__[0])' || python cairocffi/ffi_build.py"
 script: "py.test"
+sudo: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst CHANGES LICENSE tox.ini .coveragerc
 recursive-include docs *
 prune docs/_build
+exclude cairocffi/_ffi*.py

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -11,11 +11,11 @@
 """
 
 import sys
-from cffi import FFI
 
 from . import constants
 from .compat import FileNotFoundError
 
+from ._ffi import ffi
 
 VERSION = '0.6'
 # pycairo compat:
@@ -34,8 +34,6 @@ def dlopen(ffi, *names):
     return ffi.dlopen(names[0])  # pragma: no cover
 
 
-ffi = FFI()
-ffi.cdef(constants._CAIRO_HEADERS)
 CAIRO_NAMES = ['libcairo.so.2', 'libcairo.2.dylib', 'libcairo-2.dll',
                'cairo', 'libcairo-2']
 cairo = dlopen(ffi, *CAIRO_NAMES)

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -15,7 +15,11 @@ import sys
 from . import constants
 from .compat import FileNotFoundError
 
-from ._ffi import ffi
+try:
+    from ._ffi import ffi
+except ImportError:
+    # PyPy < 2.6 compatibility
+    from .ffi_build import ffi
 
 VERSION = '0.6'
 # pycairo compat:

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -24,7 +24,9 @@ import constants
 
 # Primary cffi definitions
 ffi = FFI()
-ffi.set_source('cairocffi._ffi', None)
+if hasattr(ffi, 'set_source'):
+    # PyPy < 2.6 compatibility
+    ffi.set_source('cairocffi._ffi', None)
 ffi.cdef(constants._CAIRO_HEADERS)
 
 # include xcffib cffi definitions for cairo xcb support
@@ -37,7 +39,9 @@ except ImportError:
 
 # gdk pixbuf cffi definitions
 ffi_pixbuf = FFI()
-ffi_pixbuf.set_source('cairocffi._ffi_pixbuf', None)
+if hasattr(ffi_pixbuf, 'set_source'):
+    # PyPy < 2.6 compatibility
+    ffi_pixbuf.set_source('cairocffi._ffi_pixbuf', None)
 ffi_pixbuf.include(ffi)
 ffi_pixbuf.cdef('''
     typedef unsigned long   gsize;

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -1,0 +1,103 @@
+# coding: utf8
+"""
+    cairocffi.ffi_build
+    ~~~~~~~~~~~~~~~~~~~
+
+    Build the cffi bindings
+
+    :copyright: Copyright 2013 by Simon Sapin
+    :license: BSD, see LICENSE for details.
+
+"""
+
+import os
+import sys
+from cffi import FFI
+
+# Path hack to import constants when this file is exec'd by setuptools
+this_file = os.path.abspath(__file__)
+this_dir = os.path.split(this_file)[0]
+sys.path.append(this_dir)
+
+import constants
+
+
+# Primary cffi definitions
+ffi = FFI()
+ffi.set_source('cairocffi._ffi', None)
+ffi.cdef(constants._CAIRO_HEADERS)
+
+# include xcffib cffi definitions for cairo xcb support
+try:
+    from xcffib.ffi_build import ffi as xcb_ffi
+    ffi.include(xcb_ffi)
+    ffi.cdef(constants._CAIRO_XCB_HEADERS)
+except ImportError:
+    pass
+
+# gdk pixbuf cffi definitions
+ffi_pixbuf = FFI()
+ffi_pixbuf.set_source('cairocffi._ffi_pixbuf', None)
+ffi_pixbuf.include(ffi)
+ffi_pixbuf.cdef('''
+    typedef unsigned long   gsize;
+    typedef unsigned int    guint32;
+    typedef unsigned int    guint;
+    typedef unsigned char   guchar;
+    typedef char            gchar;
+    typedef int             gint;
+    typedef gint            gboolean;
+    typedef guint32         GQuark;
+    typedef void*           gpointer;
+    typedef ...             GdkPixbufLoader;
+    typedef ...             GdkPixbufFormat;
+    typedef ...             GdkPixbuf;
+    typedef struct {
+        GQuark              domain;
+        gint                code;
+        gchar              *message;
+    } GError;
+    typedef enum {
+        GDK_COLORSPACE_RGB
+    } GdkColorspace;
+
+
+    GdkPixbufLoader * gdk_pixbuf_loader_new          (void);
+    GdkPixbufFormat * gdk_pixbuf_loader_get_format   (GdkPixbufLoader *loader);
+    GdkPixbuf *       gdk_pixbuf_loader_get_pixbuf   (GdkPixbufLoader *loader);
+    gboolean          gdk_pixbuf_loader_write        (
+        GdkPixbufLoader *loader, const guchar *buf, gsize count,
+        GError **error);
+    gboolean          gdk_pixbuf_loader_close        (
+        GdkPixbufLoader *loader, GError **error);
+
+    gchar *           gdk_pixbuf_format_get_name     (GdkPixbufFormat *format);
+
+    GdkColorspace     gdk_pixbuf_get_colorspace      (const GdkPixbuf *pixbuf);
+    int               gdk_pixbuf_get_n_channels      (const GdkPixbuf *pixbuf);
+    gboolean          gdk_pixbuf_get_has_alpha       (const GdkPixbuf *pixbuf);
+    int               gdk_pixbuf_get_bits_per_sample (const GdkPixbuf *pixbuf);
+    int               gdk_pixbuf_get_width           (const GdkPixbuf *pixbuf);
+    int               gdk_pixbuf_get_height          (const GdkPixbuf *pixbuf);
+    int               gdk_pixbuf_get_rowstride       (const GdkPixbuf *pixbuf);
+    guchar *          gdk_pixbuf_get_pixels          (const GdkPixbuf *pixbuf);
+    gsize             gdk_pixbuf_get_byte_length     (const GdkPixbuf *pixbuf);
+    gboolean          gdk_pixbuf_save_to_buffer      (
+        GdkPixbuf *pixbuf, gchar **buffer, gsize *buffer_size,
+        const char *type, GError **error, ...);
+
+    void              gdk_cairo_set_source_pixbuf    (
+        cairo_t *cr, const GdkPixbuf *pixbuf,
+        double pixbuf_x, double pixbuf_y);
+
+
+    void              g_object_ref                   (gpointer object);
+    void              g_object_unref                 (gpointer object);
+    void              g_error_free                   (GError *error);
+    void              g_type_init                    (void);
+''')
+
+
+if __name__ == '__main__':
+    ffi.compile()
+    ffi_pixbuf.compile()

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -11,81 +11,16 @@
 """
 
 import sys
-import ctypes
 from io import BytesIO
 from functools import partial
 from array import array
 
-import cffi
-
-from . import ffi as cairo_ffi, dlopen, ImageSurface, Context, constants
+from . import dlopen, ImageSurface, Context, constants
+from ._ffi_pixbuf import ffi
 from .compat import xrange
 
 
 __all__ = ['decode_to_image_surface']
-
-
-ffi = cffi.FFI()
-ffi.include(cairo_ffi)
-ffi.cdef('''
-
-    typedef unsigned long   gsize;
-    typedef unsigned int    guint32;
-    typedef unsigned int    guint;
-    typedef unsigned char   guchar;
-    typedef char            gchar;
-    typedef int             gint;
-    typedef gint            gboolean;
-    typedef guint32         GQuark;
-    typedef void*           gpointer;
-    typedef ...             GdkPixbufLoader;
-    typedef ...             GdkPixbufFormat;
-    typedef ...             GdkPixbuf;
-    typedef struct {
-        GQuark              domain;
-        gint                code;
-        gchar              *message;
-    } GError;
-    typedef enum {
-        GDK_COLORSPACE_RGB
-    } GdkColorspace;
-
-
-    GdkPixbufLoader * gdk_pixbuf_loader_new          (void);
-    GdkPixbufFormat * gdk_pixbuf_loader_get_format   (GdkPixbufLoader *loader);
-    GdkPixbuf *       gdk_pixbuf_loader_get_pixbuf   (GdkPixbufLoader *loader);
-    gboolean          gdk_pixbuf_loader_write        (
-        GdkPixbufLoader *loader, const guchar *buf, gsize count,
-        GError **error);
-    gboolean          gdk_pixbuf_loader_close        (
-        GdkPixbufLoader *loader, GError **error);
-
-    gchar *           gdk_pixbuf_format_get_name     (GdkPixbufFormat *format);
-
-    GdkColorspace     gdk_pixbuf_get_colorspace      (const GdkPixbuf *pixbuf);
-    int               gdk_pixbuf_get_n_channels      (const GdkPixbuf *pixbuf);
-    gboolean          gdk_pixbuf_get_has_alpha       (const GdkPixbuf *pixbuf);
-    int               gdk_pixbuf_get_bits_per_sample (const GdkPixbuf *pixbuf);
-    int               gdk_pixbuf_get_width           (const GdkPixbuf *pixbuf);
-    int               gdk_pixbuf_get_height          (const GdkPixbuf *pixbuf);
-    int               gdk_pixbuf_get_rowstride       (const GdkPixbuf *pixbuf);
-    guchar *          gdk_pixbuf_get_pixels          (const GdkPixbuf *pixbuf);
-    gsize             gdk_pixbuf_get_byte_length     (const GdkPixbuf *pixbuf);
-    gboolean          gdk_pixbuf_save_to_buffer      (
-        GdkPixbuf *pixbuf, gchar **buffer, gsize *buffer_size,
-        const char *type, GError **error, ...);
-
-    void              gdk_cairo_set_source_pixbuf    (
-        cairo_t *cr, const GdkPixbuf *pixbuf,
-        double pixbuf_x, double pixbuf_y);
-
-
-    void              g_object_ref                   (gpointer object);
-    void              g_object_unref                 (gpointer object);
-    void              g_error_free                   (GError *error);
-    void              g_type_init                    (void);
-
-''')
 
 gdk_pixbuf = dlopen(ffi, 'gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0-0',
                     'libgdk_pixbuf-2.0.so')

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -16,9 +16,13 @@ from functools import partial
 from array import array
 
 from . import dlopen, ImageSurface, Context, constants
-from ._ffi_pixbuf import ffi
 from .compat import xrange
 
+try:
+    from ._ffi_pixbuf import ffi
+except ImportError:
+    # PyPy < 2.6 compatibility
+    from .ffi_build import ffi_pixbuf as ffi
 
 __all__ = ['decode_to_image_surface']
 

--- a/cairocffi/surfaces.py
+++ b/cairocffi/surfaces.py
@@ -720,7 +720,7 @@ class ImageSurface(Surface):
         """
         return ffi.buffer(
             cairo.cairo_image_surface_get_data(self._pointer),
-            size=self.get_stride() * self.get_height())
+            self.get_stride() * self.get_height())
 
     def get_format(self):
         """Return the :ref:`FORMAT` string of the surface."""

--- a/cairocffi/test_xcb.py
+++ b/cairocffi/test_xcb.py
@@ -13,11 +13,12 @@
 
 import os
 import time
-import xcffib
-import xcffib.xproto
-from xcffib.xproto import ConfigWindow, CW, EventMask, GC
 
 import pytest
+
+xcffib = pytest.importorskip('xcffib')
+import xcffib.xproto
+from xcffib.xproto import ConfigWindow, CW, EventMask, GC
 
 from . import Context, XCBSurface, cairo_version
 

--- a/cairocffi/test_xcb.py
+++ b/cairocffi/test_xcb.py
@@ -105,7 +105,7 @@ def create_gc(conn):
 
 
 def test_xcb_pixmap(xcb_conn):
-    if cairo_version() < 12000:
+    if cairo_version() < 11200:
         pytest.xfail()
 
     width = 10
@@ -157,7 +157,7 @@ def test_xcb_pixmap(xcb_conn):
 
 
 def test_xcb_window(xcb_conn):
-    if cairo_version() < 12000:
+    if cairo_version() < 11200:
         pytest.xfail()
 
     width = 10

--- a/cairocffi/xcb.py
+++ b/cairocffi/xcb.py
@@ -8,14 +8,10 @@
     :copyright: Copyright 2014 by Simon Sapin
     :license: BSD, see LICENSE for details.
 """
-from xcffib import ffi as xcb_ffi, visualtype_to_c_struct
+from xcffib import visualtype_to_c_struct
 
-from . import ffi, dlopen, constants, CAIRO_NAMES
+from . import cairo, constants
 from .surfaces import Surface, SURFACE_TYPE_TO_CLASS
-
-ffi.include(xcb_ffi)
-ffi.cdef(constants._CAIRO_XCB_HEADERS)
-cairo_xcb = dlopen(ffi, *CAIRO_NAMES)
 
 
 class XCBSurface(Surface):
@@ -38,7 +34,7 @@ class XCBSurface(Surface):
     def __init__(self, conn, drawable, visual, width, height):
         c_visual = visualtype_to_c_struct(visual)
 
-        p = cairo_xcb.cairo_xcb_surface_create(
+        p = cairo.cairo_xcb_surface_create(
             conn._conn, drawable, c_visual, width, height)
         Surface.__init__(self, p)
 
@@ -57,7 +53,7 @@ class XCBSurface(Surface):
         :param width: integer
         :param height: integer
         """
-        cairo_xcb.cairo_xcb_surface_set_size(self._pointer, width, height)
+        cairo.cairo_xcb_surface_set_size(self._pointer, width, height)
         self._check_status()
 
 SURFACE_TYPE_TO_CLASS[constants.SURFACE_TYPE_XCB] = XCBSurface

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
         'Topic :: Multimedia :: Graphics',
     ],
     packages=find_packages(),
-    install_requires=['cffi>=0.6'],
-    extras_require={'xcb': ['xcffib']}
+    install_requires=['cffi>=1.1.0'],
+    setup_requires=['cffi>=1.1.0'],
+    cffi_modules=[
+        'cairocffi/ffi_build.py:ffi',
+        'cairocffi/ffi_build.py:ffi_pixbuf'
+    ],
+    extras_require={'xcb': ['xcffib>=0.3.2']},
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 from os import path
 import re
 import io
+import sys
 
 
 VERSION = re.search(
@@ -17,6 +18,20 @@ LONG_DESCRIPTION = io.open(
     encoding='utf-8',
 ).read()
 
+if '_cffi_backend' in sys.builtin_module_names:
+    import _cffi_backend
+    requires_cffi = "cffi==" + _cffi_backend.__version__
+else:
+    requires_cffi = "cffi>=1.1.0"
+
+# PyPy < 2.6 compatibility
+if requires_cffi.startswith("cffi==0."):
+    cffi_args = dict()
+else:
+    cffi_args = dict(cffi_modules=[
+        'cairocffi/ffi_build.py:ffi',
+        'cairocffi/ffi_build.py:ffi_pixbuf'
+    ])
 
 setup(
     name='cairocffi',
@@ -36,11 +51,8 @@ setup(
         'Topic :: Multimedia :: Graphics',
     ],
     packages=find_packages(),
-    install_requires=['cffi>=1.1.0'],
-    setup_requires=['cffi>=1.1.0'],
-    cffi_modules=[
-        'cairocffi/ffi_build.py:ffi',
-        'cairocffi/ffi_build.py:ffi_pixbuf'
-    ],
+    install_requires=[requires_cffi],
+    setup_requires=[requires_cffi],
     extras_require={'xcb': ['xcffib>=0.3.2']},
+    **cffi_args
 )


### PR DESCRIPTION
Use the new cffi 1.0 out-of-line ffi definitions. It currently creates 2 ffi's, one containing just the cairo library definitions (including cairo xcb definitions if xcffib is installed), and one containing the pixbuf definitions, to mimic the current use of separate ffi's for calls to different libraries.

I also have added compatibility code for PyPy before the 2.6.0 release (which was yesterday), since it ships with cffi 0.9. Travis still uses 2.5.0, so this is needed until both Travis upgrades and PyPy 2.5 is dropped.

I also changed the running of the xcb tests a bit. I think the previous xfail version was off (should be 1.12, but was set to 1.20). I also made it so the test can be run without xcffib, where the relevant test module will be skipped.

The last commit is just to explicitly switch to use Travis Docker containers, rather than VM's. I think this feature is rolling out to newer repos that don't use sudo automatically, this explicitly enables it until that happens. This has the benefit of making Travis builds start faster and run with a bit more resources, which helped me in speeding up testing, but this commit can be ignored.

Closes #58
Closes #59