### PR TITLE
Allow ffi import when package pip installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ python:
 install:
   - "pip install xcffib"
   - "pip install ."
-  - "python -c 'import cffi, sys; sys.exit(cffi.__version_info__[0])' || python cairocffi/ffi_build.py"
 script: "py.test"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 install:
   - "pip install xcffib"
   - "pip install ."

--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -16,7 +16,7 @@ from . import constants
 from .compat import FileNotFoundError
 
 try:
-    from ._ffi import ffi
+    from cairocffi._ffi import ffi
 except ImportError:
     # PyPy < 2.6 compatibility
     from .ffi_build import ffi

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -19,7 +19,7 @@ from . import dlopen, ImageSurface, Context, constants
 from .compat import xrange
 
 try:
-    from ._ffi_pixbuf import ffi
+    from cairocffi._ffi_pixbuf import ffi
 except ImportError:
     # PyPy < 2.6 compatibility
     from .ffi_build import ffi_pixbuf as ffi

--- a/cairocffi/test_xcb.py
+++ b/cairocffi/test_xcb.py
@@ -104,10 +104,9 @@ def create_gc(conn):
     return gc
 
 
+@pytest.mark.xfail(cairo_version() < 11200,
+                   reason="Cairo version too low")
 def test_xcb_pixmap(xcb_conn):
-    if cairo_version() < 11200:
-        pytest.xfail()
-
     width = 10
     height = 10
 
@@ -156,10 +155,9 @@ def test_xcb_pixmap(xcb_conn):
         event = xcb_conn.poll_for_event()
 
 
+@pytest.mark.xfail(cairo_version() < 11200,
+                   reason="Cairo version too low")
 def test_xcb_window(xcb_conn):
-    if cairo_version() < 11200:
-        pytest.xfail()
-
     width = 10
     height = 10
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py26-cairo-1.8.2, py26-cairo-1.10.0, py26, py27, py32, py33, py34, pyp
 deps=
     pytest
     xcffib
-commands=py.test []
+commands=py.test [] {envsitepackagesdir}/cairocffi
 
 [testenv:py26-cairo-1.8.2]
 ; Building old cairo on an modern system might require setting


### PR DESCRIPTION
Import the built ffi modules from `cairocffi._ffi` rather that `._ffi`, so that if the package has been installed, this will pick up the compiled modules that are installed rather than insisting they be re-built in the source directory. This has the unfortunate side-effect of possibly hiding any problems if the cdefs are changed but the package is not re-built in the source tree.

Also, get the XCB tests running on Travis, though they will be xfailed until Travis bumps to Ubuntu 14.04.