### PR TITLE
Fix loading of gdk_pixbuf library on Ubuntu (fix #63)

### DIFF
--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -27,9 +27,11 @@ except ImportError:
 __all__ = ['decode_to_image_surface']
 
 gdk_pixbuf = dlopen(ffi, 'gdk_pixbuf-2.0', 'libgdk_pixbuf-2.0-0',
-                    'libgdk_pixbuf-2.0.so')
-gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so')
-glib = dlopen(ffi, 'glib-2.0', 'libglib-2.0-0', 'libglib-2.0.so')
+                    'libgdk_pixbuf-2.0.so', 'libgdk_pixbuf-2.0.so.0')
+gobject = dlopen(ffi, 'gobject-2.0', 'libgobject-2.0-0', 'libgobject-2.0.so',
+                 'libgobject-2.0.so.0')
+glib = dlopen(ffi, 'glib-2.0', 'libglib-2.0-0', 'libglib-2.0.so',
+              'libglib-2.0.so.0')
 try:
     gdk = dlopen(ffi, 'gdk-3', 'gdk-x11-2.0', 'libgdk-win32-2.0-0',
                  'libgdk-x11-2.0.so')


### PR DESCRIPTION
This PR fixes issue #63 on Ubuntu by adding a suffix `.0` to the library name to search.

Maybe a more elegant solution would be to use `ctypes.util.find_library('gdk_pixbuf')`. I did not test on other distros or platforms but it works on Ubuntu.