### PR TITLE
Replace utf8 with utf-8 for gettext compatibility

### DIFF
--- a/cairocffi/__init__.py
+++ b/cairocffi/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi
     ~~~~~~~~~

--- a/cairocffi/compat.py
+++ b/cairocffi/compat.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.compat
     ~~~~~~~~~~~~~~~~

--- a/cairocffi/context.py
+++ b/cairocffi/context.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.context
     ~~~~~~~~~~~~~~~~~

--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.ffi_build
     ~~~~~~~~~~~~~~~~~~~

--- a/cairocffi/fonts.py
+++ b/cairocffi/fonts.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.fonts
     ~~~~~~~~~~~~~~~

--- a/cairocffi/matrix.py
+++ b/cairocffi/matrix.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.matrix
     ~~~~~~~~~~~~~~~~

--- a/cairocffi/patterns.py
+++ b/cairocffi/patterns.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.patterns
     ~~~~~~~~~~~~~~~~~~

--- a/cairocffi/pixbuf.py
+++ b/cairocffi/pixbuf.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.pixbuf
     ~~~~~~~~~~~~~~~~

--- a/cairocffi/surfaces.py
+++ b/cairocffi/surfaces.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.surface
     ~~~~~~~~~~~~~~~~~

--- a/cairocffi/test_cairo.py
+++ b/cairocffi/test_cairo.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.tests
     ~~~~~~~~~~~~~~~

--- a/cairocffi/test_pixbuf.py
+++ b/cairocffi/test_pixbuf.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.test_pixbuf
     ~~~~~~~~~~~~~~~~~~~~~

--- a/cairocffi/test_xcb.py
+++ b/cairocffi/test_xcb.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
 
     cairocffi.test_xcb

--- a/cairocffi/xcb.py
+++ b/cairocffi/xcb.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 """
     cairocffi.xcb
     ~~~~~~~~~~~~~

--- a/utils/cairo_coverage.py
+++ b/utils/cairo_coverage.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import inspect
 import pycparser

--- a/utils/cairocffi_to_pycairo.py
+++ b/utils/cairocffi_to_pycairo.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import ctypes
 import cairo  # pycairo

--- a/utils/compare_pycairo.py
+++ b/utils/compare_pycairo.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import cairo as pycairo
 import cairocffi

--- a/utils/mkconstants.py
+++ b/utils/mkconstants.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 import os
 import sys
 import re

--- a/utils/pango_example.py
+++ b/utils/pango_example.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 import cairocffi
 import cffi
 

--- a/utils/pycairo_to_cairocffi.py
+++ b/utils/pycairo_to_cairocffi.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import cairo  # pycairo
 import cairocffi

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# coding: utf-8
 
 import io
 import cairo  # pycairo


### PR DESCRIPTION
See: http://stackoverflow.com/questions/4370035/django-makemessages-errors-unknown-encoding-utf8

This will fix:
<pre>
CommandError: errors happened while running xgettext on __init__.py
xgettext: ./venv/lib/python3.4/site-packages/cairocffi/__init__.py:1: Unknown encoding "utf8". Proceeding with ASCII instead.
xgettext: Non-ASCII string at ./venv/lib/python3.4/site-packages/cairocffi/__init__.py:99.
          Please specify the source encoding through --from-code or through a comment
          as specified in http://www.python.org/peps/pep-0263.html.
</pre>