### PR TITLE
Avoid implicit relative import

### DIFF
--- a/cairocffi/ffi_build.py
+++ b/cairocffi/ffi_build.py
@@ -19,7 +19,7 @@ this_file = os.path.abspath(__file__)
 this_dir = os.path.split(this_file)[0]
 sys.path.append(this_dir)
 
-import constants
+from cairocffi import constants
 
 
 # Primary cffi definitions


### PR DESCRIPTION
This was causing problems on a recent install (Debian, Python 2.7.11) which would yield the following traceback:

```
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/home/curtis/src/git/cairocffi/setup.py", line 65, in <module>
        **cffi_args
      File "/usr/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/curtis/src/hg/zuus/env/local/lib/python2.7/site-packages/setuptools/dist.py", line 272, in __init__
        _Distribution.__init__(self,attrs)
      File "/usr/lib/python2.7/distutils/dist.py", line 287, in __init__
        self.finalize_options()
      File "/home/curtis/src/hg/zuus/env/local/lib/python2.7/site-packages/setuptools/dist.py", line 327, in finalize_options
        ep.load()(self, ep.name, value)
      File "/home/curtis/src/git/cairocffi/.eggs/cffi-1.4.1-py2.7-linux-x86_64.egg/cffi/setuptools_ext.py", line 161, in cffi_modules
        add_cffi_module(dist, cffi_module)
      File "/home/curtis/src/git/cairocffi/.eggs/cffi-1.4.1-py2.7-linux-x86_64.egg/cffi/setuptools_ext.py", line 48, in add_cffi_module
        execfile(build_file_name, mod_vars)
      File "/home/curtis/src/git/cairocffi/.eggs/cffi-1.4.1-py2.7-linux-x86_64.egg/cffi/setuptools_ext.py", line 24, in execfile
        exec(code, glob, glob)
      File "cairocffi/ffi_build.py", line 30, in <module>
        ffi.cdef(constants._CAIRO_HEADERS)
    AttributeError: 'module' object has no attribute '_CAIRO_HEADERS'
```